### PR TITLE
[SE-3584] Adds option to disable all downloads for all pdf xblocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ Go to `Settings -> Advanced Settings` and set `advanced_modules` to `["pdf"]`.
 
 Select `Advanced -> PDF` in your unit.
 
+### Custom Configurations
+
+Below is a table of custom django settings configurations that can be used with the xblock.
+
+| Configuration | Description |
+|---- |---- |
+| `PDFXBLOCK_DISABLE_ALL_DOWNLOAD` | Disables all downloadables (download pdf/source) in the XBlock if set to `True`. Overrides all custom download pdf options set in Studio, without overwriting them.
+
 ## Development environment
 
 For the code quality environment, you need to install both Python and JavaScript requirements.

--- a/pdf/pdf.py
+++ b/pdf/pdf.py
@@ -7,6 +7,11 @@ from xblock.core import XBlock
 from xblock.fields import Scope, String, Boolean
 from xblock.fragment import Fragment
 
+from pdf.utils import (
+    bool_from_str,
+    is_all_download_disabled,
+)
+
 
 class PdfBlock(XBlock):
 
@@ -85,6 +90,7 @@ class PdfBlock(XBlock):
             'display_name': self.display_name,
             'url': self.url,
             'allow_download': self.allow_download,
+            'disable_all_download': is_all_download_disabled(),
             'source_text': self.source_text,
             'source_url': self.source_url
         }
@@ -111,6 +117,7 @@ class PdfBlock(XBlock):
             'display_name': self.display_name,
             'url': self.url,
             'allow_download': self.allow_download,
+            'disable_all_download': is_all_download_disabled(),
             'source_text': self.source_text,
             'source_url': self.source_url
         }
@@ -140,7 +147,7 @@ class PdfBlock(XBlock):
         """
         self.display_name = data['display_name']
         self.url = data['url']
-        self.allow_download = True if data['allow_download'] == "True" else False  # Str to Bool translation
+        self.allow_download = bool_from_str(data['allow_download'])
         self.source_text = data['source_text']
         self.source_url = data['source_url']
 

--- a/pdf/static/html/pdf_edit.html
+++ b/pdf/static/html/pdf_edit.html
@@ -18,6 +18,7 @@
       <span class="tip setting-help">{% trans "The URL for your PDF." %}</span>
     </li>
 
+    {% if not disable_all_download %}
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
         <label class="label setting-label" for="pdf_edit_allow_download">{% trans "PDF Download Allowed" %}</label>
@@ -40,6 +41,7 @@
       </div>
       <span class="tip setting-help">{% trans "Add a download link for the source file of your PDF. Use it for example to provide the PowerPoint file used to create this PDF." %}</span>
     </li>
+    {% endif %}
 
   </ul>
 

--- a/pdf/static/html/pdf_view.html
+++ b/pdf/static/html/pdf_view.html
@@ -6,7 +6,7 @@
       {% trans "It appears you don't have a PDF plugin for this browser." %}
     </p>
   </object>
-  {% if allow_download or source_url != "" %}
+  {% if not disable_all_download %}
   <ul>
     {% if allow_download %}
     <li class="pdf-download-button">

--- a/pdf/utils.py
+++ b/pdf/utils.py
@@ -18,6 +18,4 @@ def is_all_download_disabled():
     """
     Check if all download is disabled or not
     """
-    return bool_from_str(
-        getattr(settings, 'PDFXBLOCK_DISABLE_ALL_DOWNLOAD', 'False')
-    )
+    return getattr(settings, 'PDFXBLOCK_DISABLE_ALL_DOWNLOAD', False)

--- a/pdf/utils.py
+++ b/pdf/utils.py
@@ -1,0 +1,23 @@
+"""
+Utility functions for XBlock
+"""
+
+from django.conf import settings
+
+
+def bool_from_str(str_value):
+    """
+    Converts string to boolean
+    """
+    return str_value.strip().lower() in [
+        'true'
+    ]
+
+
+def is_all_download_disabled():
+    """
+    Check if all download is disabled or not
+    """
+    return bool_from_str(
+        getattr(settings, 'PDFXBLOCK_DISABLE_ALL_DOWNLOAD', 'False')
+    )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def package_data(pkg, root):
 
 setup(
     name='xblock-pdf',
-    version='1.0.1',
+    version='1.0.3',
     description='Course component (Open edX XBlock) that provides an easy way to embed a PDF',
     packages=[
         'pdf',


### PR DESCRIPTION
Adds an django setting in order to disable all downloads for all pdf xblocks on an instance.

**JIRA tickets**: SE-3584

**Sandbox URL**: 
- **LMS**: https://pdf-certificates.stage.opencraft.hosting/courses/course-v1:ABC+123+789/courseware/db2d39d3c1b241808a1a8d12153676c1/073cc304e7d045019bde2f447380baff/1?activate_block_id=block-v1%3AABC%2B123%2B789%2Btype%40vertical%2Bblock%40f9cca7c8c0b2498f8e1b593fe6f8d769
- **Studio**: https://studio.pdf-certificates.stage.opencraft.hosting/container/block-v1:ABC+123+789+type@vertical+block@f9cca7c8c0b2498f8e1b593fe6f8d769#

**Testing instructions**:

1. Open the Unit in Studio, linked above, and edit the XBlock. Make sure that the download options don't show up.
2. Open the Unit in the LMS, linked above, and edit the XBlock. Make sure that the "Download PDF" doesn't show up.
3. SSH into the app server on Stage, and edit `/edx/etc/lms.yml` and set `PDFXBLOCK_DISABLE_ALL_DOWNLOAD` to `False`.
4. Also edit `/edx/etc/studio.yml` and set `PDFXBLOCK_DISABLE_ALL_DOWNLOAD` to `False`.
5. Restart `CMS` and `LMS`, and check steps 1 and 2 again (for the opposite condition).

**Reviewers**
- [x] @Kelketek