### PR TITLE
[SE-3584] Fixes issue when saving XBlock with download disabled

### DIFF
--- a/pdf/pdf.py
+++ b/pdf/pdf.py
@@ -147,9 +147,11 @@ class PdfBlock(XBlock):
         """
         self.display_name = data['display_name']
         self.url = data['url']
-        self.allow_download = bool_from_str(data['allow_download'])
-        self.source_text = data['source_text']
-        self.source_url = data['source_url']
+        
+        if not is_all_download_disabled():
+            self.allow_download = bool_from_str(data['allow_download'])
+            self.source_text = data['source_text']
+            self.source_url = data['source_url']
 
         return {
             'result': 'success',

--- a/pdf/static/js/pdf_edit.js
+++ b/pdf/static/js/pdf_edit.js
@@ -7,10 +7,10 @@ function pdfXBlockInitEdit(runtime, element) {
     $(element).find('.action-save').bind('click', function () {
         var data = {
             'display_name': $('#pdf_edit_display_name').val(),
-            url: $('#pdf_edit_url').val(),
-            'allow_download': $('#pdf_edit_allow_download').val(),
-            'source_text': $('#pdf_edit_source_text').val(),
-            'source_url': $('#pdf_edit_source_url').val()
+            'url': $('#pdf_edit_url').val(),
+            'allow_download': $('#pdf_edit_allow_download').val() || '',
+            'source_text': $('#pdf_edit_source_text').val() || '',
+            'source_url': $('#pdf_edit_source_url').val() || ''
         };
 
         runtime.notify('save', { state: 'start' });

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def package_data(pkg, root):
 
 setup(
     name='xblock-pdf',
-    version='1.0.3',
+    version='1.0.4',
     description='Course component (Open edX XBlock) that provides an easy way to embed a PDF',
     packages=[
         'pdf',


### PR DESCRIPTION
Fixes issue when saving PDF XBlock that was presented with #1 

**JIRA tickets**: SE-3584

**Sandbox URL**: 
- **LMS**: https://pdf-certificates.stage.opencraft.hosting/courses/course-v1:ABC+123+789/courseware/db2d39d3c1b241808a1a8d12153676c1/073cc304e7d045019bde2f447380baff/1?activate_block_id=block-v1%3AABC%2B123%2B789%2Btype%40vertical%2Bblock%40f9cca7c8c0b2498f8e1b593fe6f8d769
- **Studio**: https://studio.pdf-certificates.stage.opencraft.hosting/container/block-v1:ABC+123+789+type@vertical+block@f9cca7c8c0b2498f8e1b593fe6f8d769#

**Testing instructions**:

1. Edit a PDF XBlock and make sure it saves correctly.

**Reviewers**
- [x] @Kelketek