### PR TITLE
fix: PDFs not working properly in Firefox

### DIFF
--- a/pdf/templates/html/pdf_view.html
+++ b/pdf/templates/html/pdf_view.html
@@ -1,11 +1,9 @@
 {% load i18n %}
 <div class="pdf_block">
   <h2>{{ display_name }}</h2>
-  <object data="{{ url }}" type="application/pdf" width="100%" height="600">
-    <p>
-      {% trans "It appears you don't have a PDF plugin for this browser." %}
-    </p>
-  </object>
+  <iframe src="{{ url }}" type="application/pdf" width="100%" height="600">
+
+  </iframe>
   {% if not disable_all_download %}
   <ul>
     {% if allow_download %}

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-pdf',
-    version='1.1.0',
+    version='1.2.0',
     description='Course component (Open edX XBlock) that provides an easy way to embed a PDF',
     packages=[
         'pdf',


### PR DESCRIPTION
Switching from a object tag to an iframe seems to fix this issue on Firefox.

Private-ref: [BB-9624](https://tasks.opencraft.com/browse/BB-9624)