### PR TITLE
feat: remove PDF download button and option

### DIFF
--- a/pdf/pdf.py
+++ b/pdf/pdf.py
@@ -27,7 +27,7 @@ class PdfBlock(XBlock):
     Icon of the XBlock. Values : [other (default), video, problem]
     """
     icon_class = "other"
-    editable_fields = ('display_name', 'url', 'allow_download', 'source_text', 'source_url')
+    editable_fields = ('display_name', 'url', 'source_text', 'source_url')
 
     # Fields
     display_name = String(
@@ -42,13 +42,6 @@ class PdfBlock(XBlock):
         default=_("https://tutorial.math.lamar.edu/pdf/Trig_Cheat_Sheet.pdf"),
         scope=Scope.content,
         help=_("The URL for your PDF.")
-    )
-
-    allow_download = Boolean(
-        display_name=_("PDF Download Allowed"),
-        default=True,
-        scope=Scope.content,
-        help=_("Display a download button for this PDF.")
     )
 
     source_text = String(
@@ -97,7 +90,6 @@ class PdfBlock(XBlock):
         context = {
             'display_name': self.display_name,
             'url': self.url,
-            'allow_download': self.allow_download,
             'disable_all_download': is_all_download_disabled(),
             'source_text': self.source_text,
             'source_url': self.source_url,
@@ -129,7 +121,6 @@ class PdfBlock(XBlock):
         context = {
             'display_name': self.display_name,
             'url': self.url,
-            'allow_download': self.allow_download,
             'disable_all_download': is_all_download_disabled(),
             'source_text': self.source_text,
             'source_url': self.source_url,
@@ -144,18 +135,6 @@ class PdfBlock(XBlock):
         frag.add_javascript(self.load_resource("static/js/pdf_edit.js"))
         frag.initialize_js('pdfXBlockInitEdit')
         return frag
-
-    @XBlock.json_handler
-    def on_download(self, data, suffix=''):  # pylint: disable=unused-argument
-        """
-        The download file event handler
-        """
-        event_type = 'edx.pdf.downloaded'
-        event_data = {
-            'url': self.url,
-            'source_url': self.source_url,
-        }
-        self.runtime.publish(self, event_type, event_data)
 
     def _generate_pdf_from_source(self):
         """
@@ -178,7 +157,6 @@ class PdfBlock(XBlock):
         self.url = data['url']
 
         if not is_all_download_disabled():
-            self.allow_download = bool_from_str(data['allow_download'])
             self.source_text = data['source_text']
             self.source_url = data['source_url']
             if data['source_url'] and bool_from_str(data['pdf_auto_generate']):

--- a/pdf/static/js/pdf_edit.js
+++ b/pdf/static/js/pdf_edit.js
@@ -9,7 +9,6 @@ function pdfXBlockInitEdit(runtime, element) {
         const data = {
             'display_name': $('#pdf_edit_display_name').val(),
             'url': $('#pdf_edit_url').val(),
-            'allow_download': $('#pdf_edit_allow_download').val() || '',
             'source_text': $('#pdf_edit_source_text').val() || '',
             'source_url': $('#pdf_edit_source_url').val() || '',
             'pdf_auto_generate': $('#pdf_auto_generate').val() || '',

--- a/pdf/static/js/pdf_view.js
+++ b/pdf/static/js/pdf_view.js
@@ -8,11 +8,4 @@ function pdfXBlockInitView(runtime, element) {
     if (element.innerHTML) {
         element = $(element);
     }
-
-    $(function () {
-        element.find('.pdf-download-button').on('click', function () {
-            const handlerUrl = runtime.handlerUrl(element, 'on_download');
-            $.post(handlerUrl, '{}');
-        });
-    });
 }

--- a/pdf/templates/html/pdf_edit.html
+++ b/pdf/templates/html/pdf_edit.html
@@ -21,17 +21,6 @@
     {% if not disable_all_download %}
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <label class="label setting-label" for="pdf_edit_allow_download">{% trans "PDF Download Allowed" %}</label>
-        <select class="input setting-input" id="pdf_edit_allow_download">
-          <option value="True" {% if allow_download %}selected{% endif %}>{% trans "True" %}</option>
-          <option value="False" {% if not allow_download %}selected{% endif %}>{% trans "False" %}</option>
-        </select>
-      </div>
-      <span class="tip setting-help">{% trans "Display a download button for this PDF." %}</span>
-    </li>
-
-    <li class="field comp-setting-entry is-set">
-      <div class="wrapper-comp-setting">
         <label class="label setting-label" for="pdf_edit_source_text">{% trans "Source document button text" %}</label>
         <input class="input setting-input" id="pdf_edit_source_text" value="{{ source_text }}" type="text" placeholder="{% trans 'Default : Download the source document' %}">
       </div>

--- a/pdf/templates/html/pdf_view.html
+++ b/pdf/templates/html/pdf_view.html
@@ -8,11 +8,6 @@
   </object>
   {% if not disable_all_download %}
   <ul>
-    {% if allow_download %}
-    <li class="pdf-download-button">
-      <a href="{{ url }}" download>{% trans "Download the PDF" %}</a>
-    </li>
-    {% endif %}
     {% if source_url != "" %}
     <li class="pdf-download-button">
       <a href="{{ source_url }}" download>{% if source_text == "" %}{% trans "Download the source document" %}{% else %}{{ source_text }}{% endif %}</a>


### PR DESCRIPTION
## Description

Most browser PDF viewers will display an option for downloading the PDF. Because of this, the separate PDF download button is redundant. Also the option to uncheck "PDF Download Allowed" is misleading, because removing the button can't disallow downloading.

## Supporting information

Private-ref: https://tasks.opencraft.com/browse/BB-9935

## Testing instructions

- create and edit a pdf component
- verify there is no field for allowing pdf download
- save and view the pdf component
- verify there is no 'download pdf' button or link (besides what's in the embedded pdf viewer)
- verify that there are no errors or issues with the layout in the cms edit view, the cms view, or the lms view.

## Other information

This depends on [open-craft/xblock-pdf#5](https://github.com/open-craft/xblock-pdf/pull/5), as the branch from that PR is what is deployed and what we're testing with. If this goes ahead, the plan would be to create a new client branch based on that PR, and merge this PR into the new client branch.