### PR TITLE
docs: improve docs for download link option

### DIFF
--- a/pdf/templates/html/pdf_edit.html
+++ b/pdf/templates/html/pdf_edit.html
@@ -21,13 +21,13 @@
     {% if not disable_all_download %}
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <label class="label setting-label" for="pdf_edit_allow_download">{% trans "PDF Download Allowed" %}</label>
+        <label class="label setting-label" for="pdf_edit_allow_download">{% trans "Show PDF download link" %}</label>
         <select class="input setting-input" id="pdf_edit_allow_download">
           <option value="True" {% if allow_download %}selected{% endif %}>{% trans "True" %}</option>
           <option value="False" {% if not allow_download %}selected{% endif %}>{% trans "False" %}</option>
         </select>
       </div>
-      <span class="tip setting-help">{% trans "Display a download button for this PDF." %}</span>
+      <span class="tip setting-help">{% trans "Display a download link to this PDF for convenience. Please note that even if this is disabled, the embedded PDF viewer may still display its own download button." %}</span>
     </li>
 
     <li class="field comp-setting-entry is-set">

--- a/pdf/templates/html/pdf_view.html
+++ b/pdf/templates/html/pdf_view.html
@@ -10,7 +10,8 @@
   <ul>
     {% if allow_download %}
     <li class="pdf-download-button">
-      <a href="{{ url }}" download>{% trans "Download the PDF" %}</a>
+      <a href="{{ url }}" target="_blank" rel="noopener" download>{% trans "Download the PDF" %}</a>
+      (Right click or long press on the download link and select the "Save as" option to download. Clicking on the link might open it in a tab.)
     </li>
     {% endif %}
     {% if source_url != "" %}


### PR DESCRIPTION
## Description

Clarify that the embedded pdf viewer in the browser may also display a download button, regardless of this option. Also improve the student-facing behaviour of the download button:
- add help text for how to download
- make the link open in a new tab so students won't lose their place in the course.

## Supporting information

Private-ref: https://tasks.opencraft.com/browse/BB-9935

## Testing instructions

- create and edit a pdf block
- verify the pdf download link option name and help text make sense
- turn on the pdf download link option
- save and view the pdf block
- verify the download link is displayed
- verify the help text makes sense
- click the link and verify it opens in a new tab
- verify you can right click and save the pdf as a file